### PR TITLE
Feat: Add config OCI_IN_TRANSIT_ENCRYPTION

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ OCI_MAX_INSTANCES=1
 # NB! No new lines / line endings allowed! Put inside double quotes
 OCI_SSH_PUBLIC_KEY="ssh-ed25519 AAAAC3N***o2U user@example.com"
 
+# Set to false to disable intransit encryption. Default: true.
+OCI_IN_TRANSIT_ENCRYPTION=true
+
 # Is now optional for ARM since Always Free ARMs can be created in any AD.
 # ListAvailabilityDomains API call will be used for retrieval https://docs.oracle.com/en-us/iaas/api/#/en/identity/20160918/AvailabilityDomain/ListAvailabilityDomains
 #

--- a/index.php
+++ b/index.php
@@ -32,7 +32,8 @@ $config = new OciConfig(
     getenv('OCI_SUBNET_ID'),
     getenv('OCI_IMAGE_ID'),
     (int) getenv('OCI_OCPUS'),
-    (int) getenv('OCI_MEMORY_IN_GBS')
+    (int) getenv('OCI_MEMORY_IN_GBS'),
+    filter_var(getenv('OCI_IN_TRANSIT_ENCRYPTION'), FILTER_VALIDATE_BOOLEAN)
 );
 
 $bootVolumeSizeInGBs = (string) getenv('OCI_BOOT_VOLUME_SIZE_IN_GBS');

--- a/src/OciApi.php
+++ b/src/OciApi.php
@@ -49,6 +49,7 @@ class OciApi
     "displayName": "$displayName",
     "availabilityDomain": "$availabilityDomain",
     "sourceDetails": {$config->getSourceDetails()},
+    "isPvEncryptionInTransitEnabled": {$config->use_in_transit_encryption},
     "createVnicDetails": {
         "assignPublicIp": false,
         "subnetId": "{$config->subnetId}",

--- a/src/OciConfig.php
+++ b/src/OciConfig.php
@@ -49,7 +49,8 @@ class OciConfig
         string $subnetId,
         string $imageId,
         int $ocups = 4,
-        int $memoryInGBs = 24
+        int $memoryInGBs = 24,
+        bool $use_in_transit_encryption = true
     )
     {
         $this->region = $region;
@@ -63,6 +64,7 @@ class OciConfig
         $this->ocpus = $ocups;
         $this->memoryInGBs = $memoryInGBs;
         $this->imageId = $imageId;
+        $this->use_in_transit_encryption = $use_in_transit_encryption;
     }
 
     /**


### PR DESCRIPTION
Should Solve https://github.com/hitrov/oci-arm-host-capacity/issues/20

I added `OCI_IN_TRANSIT_ENCRYPTION` as a new env param that sets `isPvEncryptionInTransitEnabled`.

**Untested** because I do not have an account with free resources. Would greatly appreciate if someone could help test this.