### PR TITLE
Update github actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         php-versions: ['7.4', '8.0', '8.1', '8.2']
     name: integration-tests (PHP ${{ matrix.php-versions }})
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Currently, there are two warnings per each job in `tests.yml`

<img width="868" alt="image" src="https://user-images.githubusercontent.com/11611397/235352184-f1cb14bf-a8e1-4de5-bb05-9303ab8ba632.png">

> Node.js ***2 actions are deprecated. Please update the following actions to use Node.js ***6: actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node***6-instead-of-node***2/.
>
> ref) https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Because `actions/cache@v2` uses node 12.

This is fixed when upgrade cache to v3


> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-***0-***-github-actions-deprecating-save-state-and-set-output-commands/
>
> ref) https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

`set-output` is deprecated, and should be updated with `$GITHUB_OUTPUT` (or `$GITHUB_STATE`)