### PR TITLE
Use exit codes instead of return to improve control flow

### DIFF
--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ foreach ($availabilityDomains as $availabilityDomainEntity) {
             strpos($message, 'Out of host capacity') !== false
         ) {
             // trying next availability domain
-            sleep(16);
+            sleep(30);
             continue;
         }
 

--- a/index.php
+++ b/index.php
@@ -111,7 +111,7 @@ foreach ($availabilityDomains as $availabilityDomainEntity) {
         }
 
         // current config is broken
-        return;
+        exit(1);
     }
 
     // success
@@ -121,5 +121,7 @@ foreach ($availabilityDomains as $availabilityDomainEntity) {
         $notifier->notify($message);
     }
 
-    return;
+    exit(0);
 }
+
+exit(1);


### PR DESCRIPTION
First of all, I just want to thank you for the work you have put into making this great tool. It helped me finally get a server on Oracle this morning! I have been trying for months so I am incredibly grateful.

I would like to share a small improvement that I think improves the experience a little bit. If you replace the appropriate `return` statements at the bottom with `exit(1)` you could use a command like this in a tmux session or something:

```shell
$ while true; do php ./index.php && break; done
```

That would just loop until the exit code is `0`. Same concept as the cronjob without installing anything.

You could even do something like this in a systemd service file:

```yaml
[Unit]
Description=Oracle Cloud host capacity service
After=network.target

[Service]
Type=oneshot
ExecStart=test ! -e /tmp/flag && /usr/bin/php /home/user/index.php
ExecStop=touch /tmp/flag; noti # get a notification!
Restart=on-failure

[Install]
WantedBy=default.target
RequiredBy=network.target
...
```

Please let me know if you need anything else from me. Thank you again for sharing this tool!