### PR TITLE
Add a running date string to the output of index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -116,7 +116,8 @@ foreach ($availabilityDomains as $availabilityDomainEntity) {
 
     // success
     $message = json_encode($instanceDetails, JSON_PRETTY_PRINT);
-    echo "$message\n";
+    $date = date("Y-m-d H:i:s");
+    echo "$date\n$message\n";
     if ($notifier->isSupported()) {
         $notifier->notify($message);
     }


### PR DESCRIPTION
Log files with existing outputs are difficult to distinguish between logs because only the same logs are stacked.
To resolve this, the time when the log was recorded was added.