### PR TITLE
Installing `php-curl` and `php-xml` packages to fix the `composer install` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ git clone https://github.com/hitrov/oci-arm-host-capacity.git
 ```
 run
 ```bash
+sudo apt install php-curl php-xml
 cd oci-arm-host-capacity/
 composer install
 ```


### PR DESCRIPTION
After running `composer install`, I got the following error:
```bash
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - Root composer.json requires PHP extension ext-curl * but it is missing from your system. Install or enable PHP's curl extension.
  Problem 2
    - phar-io/manifest is locked to version 2.0.3 and an update of this package was not requested.
    - phar-io/manifest 2.0.3 requires ext-dom * -> it is missing from your system. Install or enable PHP's dom extension.
  Problem 3
    - phpunit/php-code-coverage is locked to version 9.2.30 and an update of this package was not requested.
    - phpunit/php-code-coverage 9.2.30 requires ext-dom * -> it is missing from your system. Install or enable PHP's dom extension.
  Problem 4
    - phpunit/phpunit is locked to version 9.6.15 and an update of this package was not requested.
    - phpunit/phpunit 9.6.15 requires ext-dom * -> it is missing from your system. Install or enable PHP's dom extension.
  Problem 5
    - theseer/tokenizer is locked to version 1.2.2 and an update of this package was not requested.
    - theseer/tokenizer 1.2.2 requires ext-dom * -> it is missing from your system. Install or enable PHP's dom extension.

To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/8.2/cli/php.ini
    - /etc/php/8.2/cli/conf.d/10-opcache.ini
    - /etc/php/8.2/cli/conf.d/10-pdo.ini
    - /etc/php/8.2/cli/conf.d/20-calendar.ini
    - /etc/php/8.2/cli/conf.d/20-ctype.ini
    - /etc/php/8.2/cli/conf.d/20-exif.ini
    - /etc/php/8.2/cli/conf.d/20-ffi.ini
    - /etc/php/8.2/cli/conf.d/20-fileinfo.ini
    - /etc/php/8.2/cli/conf.d/20-ftp.ini
    - /etc/php/8.2/cli/conf.d/20-gettext.ini
    - /etc/php/8.2/cli/conf.d/20-iconv.ini
    - /etc/php/8.2/cli/conf.d/20-intl.ini
    - /etc/php/8.2/cli/conf.d/20-mbstring.ini
    - /etc/php/8.2/cli/conf.d/20-pdo_sqlite.ini
    - /etc/php/8.2/cli/conf.d/20-phar.ini
    - /etc/php/8.2/cli/conf.d/20-posix.ini
    - /etc/php/8.2/cli/conf.d/20-readline.ini
    - /etc/php/8.2/cli/conf.d/20-shmop.ini
    - /etc/php/8.2/cli/conf.d/20-sockets.ini
    - /etc/php/8.2/cli/conf.d/20-sqlite3.ini
    - /etc/php/8.2/cli/conf.d/20-sysvmsg.ini
    - /etc/php/8.2/cli/conf.d/20-sysvsem.ini
    - /etc/php/8.2/cli/conf.d/20-sysvshm.ini
    - /etc/php/8.2/cli/conf.d/20-tokenizer.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-curl --ignore-platform-req=ext-dom` to temporarily ignore these required extensions.
```
It was solved after installing the required `php-curl` and `php-xml` packages and running `composer install` again.